### PR TITLE
Role Trust Principal Support

### DIFF
--- a/bin/iam_template_build.py
+++ b/bin/iam_template_build.py
@@ -103,7 +103,6 @@ def build_role_trust(c, trusts):
     web_principals = []
 
     for trust in trusts:
-        print "Testing against '{}'".format(trust)
         # See if we match an account:
         # First see if we match an account friendly name.
         trust_account = c.search_accounts([trust])
@@ -134,8 +133,10 @@ def build_role_trust(c, trusts):
         # Otherwise raise a value-error
         else:
             raise ValueError(
-                "Unable to find trust name '{}' in the config.yaml. "
-                "Assure it exists in the account section.".format(
+                "Trust name '{}' in the config.yaml does not appear to be "
+                "valid.  Confirm it is a valid AWS Principal ARN / AWS "
+                "Service Principal or an Account Name / SAML Provider "
+                "contained in the config.yaml".format(
                     trust
                 )
             )

--- a/bin/lib/config_helper.py
+++ b/bin/lib/config_helper.py
@@ -95,10 +95,10 @@ class config(object):
         # We permit a few special keywords to make our users lives easier.
         for pattern in pattern_list:
             found = False
-            # If our pattern is a service name (denoted by a dot) we will
-            # not raise an exception about an invalid account
+            # If our pattern is a service name or ARN (denoted by a dot or 
+            # Colon we will not raise an exception about an invalid account
             # but we won't populate our matched list.
-            if '.' in pattern:
+            if '.' in pattern or ':' in pattern:
                 found = True
             # If our pattern is a SAML provider we will not raise an exception
             # but won't populate a match.


### PR DESCRIPTION
Given valid principals described here:
https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_principal.html

Including support for more of those principals in the `trust:` section of a role.  Previously only supported a SAML provider, AWS Service, or an AWS account.  Added support for user/role/federated role and web federation.  Don't support the '*' principal since this is really only used with a conditional.

Conditional support is something to be discussed.  Maybe makes more sense in a Jinja template given the number of variables involved.