### PR TITLE
Resolve PyYAML yaml.load(input) Deprecation issue

### DIFF
--- a/bin/lib/config_helper.py
+++ b/bin/lib/config_helper.py
@@ -51,7 +51,7 @@ class config(object):
     # Read our config file and build a few helper constructs from it.
     def __init__(self, config_file):
         # Read our YAML
-        self.config = yaml.load(open(config_file).read())
+        self.config = yaml.load(open(config_file).read(), Loader=yaml.FullLoader)
         # We will use our current timestamp in UTC as our build version
         self.build_version = \
             datetime.datetime.utcnow().strftime("%Y-%m-%dZ%H:%M:%S")


### PR DESCRIPTION
Resolves runtime error.  See https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation for an explanation of the issue.

*Issue #, if available:*
The current code isn't running with Python 3.7.  This is due to a CVE that was filed against the YAML library. 

*Description of changes:*
Per the docs, the best way to stop getting the warning is to specify the Loader= argument like so:

`yaml.load(input, Loader=yaml.FullLoader)`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

