### PR TITLE
Feature/permissions boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,8 +377,29 @@ This will generate the following assume role policy document automatically . . .
   ]
 }
 ```
-
 . . . and place it (along with the role definition) in the parent CloudFormation template.
+
+#### Example of a role with a permission boundary
+
+```yaml
+roles:
+  NetworkAdmin:
+    trusts:
+      - parent
+    managed_policies:
+      - arn:aws:iam::aws:policy/job-function/NetworkAdministrator
+      - arn:aws:iam::aws:policy/ReadOnlyAccess
+      - cloudFormationAdmin
+    permissions_boundary: developerBoundary
+    in_accounts:
+      - all
+    max_role_duration: 3600
+```
+
+As above if will create it will create a role called NetworkAdmin. But now it will also add an IAM Permissions Boundary
+which limits the permissions granted to a user with that role to what boundaries are set in the `developerBoundary`
+manage policy. You can also provide an ARN directly.
+
 
 ### `users:` section
 

--- a/sample_configs/config-complex.yaml
+++ b/sample_configs/config-complex.yaml
@@ -19,6 +19,9 @@ accounts:
     id: 209876543210
 
 policies:
+  testBoundary:
+    description: A permissions boundary managed policy
+    policy_file: permissionsBoundary.j2
   cloudFormationAdmin:
     description: CloudFormation Administrator
     policy_file: cloudFormationAdmin.j2
@@ -134,6 +137,7 @@ roles:
       - restrictedSubnets
     in_accounts:
       - all
+    permissions_boundary: testBoundary
 
   AdminRole:
     trusts:
@@ -142,6 +146,7 @@ roles:
       - arn:aws:iam::aws:policy/AdministratorAccess
     in_accounts:
       - all
+    permissions_boundary: arn:aws:iam::aws:policy/TestBoundary
 
   NetworkAdmin:
     trusts:

--- a/sample_policy/permissionsBoundary.j2
+++ b/sample_policy/permissionsBoundary.j2
@@ -1,0 +1,23 @@
+{
+	"Version": "2012-10-17",
+	"Statement": [
+		{
+			"Sid": "PermissionsBoundaryPolicyOnlyUsableIfBoundaryIsAttached",
+			"Effect": "Allow",
+			"Action": [
+				"iam:AddRoleToInstanceProfile",
+				"iam:List*",
+				"iam:PassRole"
+			],
+			"Resource": [
+				"arn:aws:lambda:*:*:function:{{ template_vars.shared_services_prefix }}*"
+			],
+			"Condition": {
+                "StringEquals": {
+					"iam:PermissionsBoundary": "arn:aws:iam::{{ account }}:policy/TestBoundaryName"
+                }
+            }
+
+		}
+	]
+}

--- a/sample_policy_yaml/permissionsBoundary.j2
+++ b/sample_policy_yaml/permissionsBoundary.j2
@@ -1,7 +1,7 @@
 ---
 Version: "2012-10-17"
 Statement:
-  - Sid: "UserIAMGrants"
+  - Sid: "PermissionsBoundaryPolicyOnlyUsableIfBoundaryIsAttached"
     Effect: "Allow"
     Action:
       - "iam:AddRoleToInstanceProfile"
@@ -10,4 +10,4 @@ Statement:
     Resource: "*"
     Condition:
       StringEquals:
-        "iam:PermissionsBoundary": "arn:aws:iam::{{ account }}:policy/bla"
+        "iam:PermissionsBoundary": "arn:aws:iam::{{ account }}:policy/TestBoundaryName"

--- a/sample_policy_yaml/permissionsBoundary.j2
+++ b/sample_policy_yaml/permissionsBoundary.j2
@@ -1,0 +1,13 @@
+---
+Version: "2012-10-17"
+Statement:
+  - Sid: "UserIAMGrants"
+    Effect: "Allow"
+    Action:
+      - "iam:AddRoleToInstanceProfile"
+      - "iam:List*"
+      - "iam:PassRole"
+    Resource: "*"
+    Condition:
+      StringEquals:
+        "iam:PermissionsBoundary": "arn:aws:iam::{{ account }}:policy/bla"

--- a/test.sh
+++ b/test.sh
@@ -36,7 +36,7 @@ test_yaml() {
 }
 
 mkdir -p ${TESTDIR}
-test_json
+# test_json
 test_yaml
 cleanup
 

--- a/test.sh
+++ b/test.sh
@@ -36,7 +36,7 @@ test_yaml() {
 }
 
 mkdir -p ${TESTDIR}
-# test_json
+test_json
 test_yaml
 cleanup
 


### PR DESCRIPTION

Added the ability to also use IAM Permissions Boundaries in Roles.

With boundaries becoming a more common feature for limiting permissions in IAM, found this feature quite useful.

- Added ability to handle `permissions_boundary` in configuration
- Added example in `README.md`
- Added sample Jinja2 templates and example in main config file to allow tests to run and show proper generation


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
